### PR TITLE
Bump v0.1.7 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.6
+version: 0.1.7
 name: disallow-service-nodeport
 displayName: Disallow Service Nodeport
-createdAt: 2023-03-24T16:40:43.045778334Z
+createdAt: 2023-07-07T18:33:05.742165346Z
 description: A policy that prevents the creation of Service resources of type `NodePort`
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/disallow-service-nodeport-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/disallow-service-nodeport:v0.1.6
+  image: ghcr.io/kubewarden/policies/disallow-service-nodeport:v0.1.7
 keywords:
 - service
 links:
 - name: policy
-  url: https://github.com/kubewarden/disallow-service-nodeport-policy/releases/download/v0.1.6/policy.wasm
+  url: https://github.com/kubewarden/disallow-service-nodeport-policy/releases/download/v0.1.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/disallow-service-nodeport-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/disallow-service-nodeport:v0.1.6
+  kwctl pull ghcr.io/kubewarden/policies/disallow-service-nodeport:v0.1.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.7 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.7

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
